### PR TITLE
Delete selected subtitles not working in search results for video

### DIFF
--- a/Contents/Code/pms.py
+++ b/Contents/Code/pms.py
@@ -213,6 +213,7 @@ class pms(object):
 				# Grap all movies from the result
 				for media in foundMedias.xpath('//Video'):
 					value = {}
+					value['key'] = media.get('ratingKey')
 					value['title'] = media.get('title')
 					value['type'] = media.get('type')
 					value['section'] = media.get('librarySectionID')			


### PR DESCRIPTION
I was getting 400 Bad Request responses when trying to delete subtitles in search results.

After inspecting the front-end, I found the root cause to be that the results of search did not contain a key.

From there I used Github search to figure out where it was happening (or not happening, depending on your view).

I then introduced a fix on my on Qnap NAS consisting of this single line.

I'm a senior dev, but new to Python, so feel free to let me know if I'm wrong, and in what way.