### PR TITLE
Fix for Greek Subs Identification

### DIFF
--- a/Contents/Code/language.py
+++ b/Contents/Code/language.py
@@ -72,7 +72,7 @@ class language(object):
 		"Irish" : "gle",
 		"Galician" : "glg",
 		"Manx" : "glv",
-		"Greek" : "ell",
+		"Greek" : "el",
 		"Guarani" : "grn",
 		"Gujarati" : "guj",
 		"Haitian" : "hat",


### PR DESCRIPTION
Plex Server doesn't identify Greek subtitles with -ell- tag, but with -el- .