### PR TITLE
Allow users to specify an IP address to bind.

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -91,9 +91,12 @@ def MainMenu():
     Log.Debug('WebPort http: ' + str(Prefs['WEB_Port_http']))
     Log.Debug('WebPort https: ' + str(Prefs['WEB_Port_https']))
     Log.Debug('BaseURL: ' + str(BASEURL))
-    url = 'http://' + str(Network.Address) + ':' + \
+    WEB_HOST = str(Network.Address)
+    if Prefs['WEB_HOST']:
+        WEB_HOST = Prefs['WEB_HOST']
+    url = 'http://' + WEB_HOST + ':' + \
         str(Prefs['WEB_Port_http']) + str(BASEURL)
-    urlhttps = 'https://' + str(Network.Address) + ':' + \
+    urlhttps = 'https://' + WEB_HOST + ':' + \
         str(Prefs['WEB_Port_https']) + str(BASEURL)
     oc.add(DirectoryObject(key=Callback(MainMenu),
                            title=L("To access this channel, type the url's below to a new browser tab")))

--- a/Contents/Code/webSrv.py
+++ b/Contents/Code/webSrv.py
@@ -1,8 +1,8 @@
 ######################################################################################################################
-#					WebTools helper unit
+#                    WebTools helper unit
 #
-#					Runs a seperate webserver on a specified port
-#					Author:			dane22, a Plex Community member
+#                    Runs a seperate webserver on a specified port
+#                    Author:            dane22, a Plex Community member
 #
 ######################################################################################################################
 
@@ -409,14 +409,14 @@ handlers = [(r"%s/login" % BASEURL, LoginHandler),
             (r"%s/uas/Resources.*$" % BASEURL, imageHandler),
             # Grap translation.js from datastore
             (r"%s/static/_shared/translations.js" % BASEURL, translateHandler),
-            (r'%s/' % BASEURL, idxHandler),																# Index
-            (r'%s' % BASEURL, idxHandler),																# Index
-            (r'%s/index.html' % BASEURL, idxHandler),													# Index
-            (r'%s/api/v3.*$' % BASEURL, apiv3.apiv3),													# API V3
+            (r'%s/' % BASEURL, idxHandler),                                                                # Index
+            (r'%s' % BASEURL, idxHandler),                                                                # Index
+            (r'%s/index.html' % BASEURL, idxHandler),                                                    # Index
+            (r'%s/api/v3.*$' % BASEURL, apiv3.apiv3),                                                    # API V3
             (r'%s/getTranslate.*$' %
-             BASEURL, getTranslationHandler),													        # getTranslation
+             BASEURL, getTranslationHandler),                                                            # getTranslation
             (r'%s/(.*)' % BASEURL, MyStaticFileHandler,
-             {'path': getActualHTTPPath()})					# Static files
+             {'path': getActualHTTPPath()})                    # Static files
             ]
 
 if Prefs['Force_SSL']:
@@ -428,7 +428,7 @@ if Prefs['Force_SSL']:
                     # Grap images from Data framework
                     (r"%s/uas/Resources.*$" % BASEURL, imageHandler),
                     (r'%s/getTranslate.*$' %
-                     BASEURL, getTranslationHandler),													 # getTranslation
+                     BASEURL, getTranslationHandler),                                                     # getTranslation
                     # Grap translation.js from datastore
                     (r"%s/static/_shared/translations.js" %
                      BASEURL, translateHandler),
@@ -467,8 +467,12 @@ def start_tornado():
         # Set web server port to the setting in the channel prefs
         port = int(Prefs['WEB_Port_http'])
         ports = int(Prefs['WEB_Port_https'])
-        http_server.listen(port)
-        http_serverTLS.listen(ports)
+        if Prefs['WEB_HOST']:        
+            http_server.listen(port, address=str(Prefs['WEB_HOST']))
+            http_serverTLS.listen(ports, address=str(Prefs['WEB_HOST']))
+        else:
+            http_server.listen(port)
+            http_serverTLS.listen(ports)
         Log.Debug('Starting tornado on ports %s and %s' % (port, ports))
         IOLoop.instance().start()
     except Exception, e:

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -12,6 +12,12 @@
         "default": "33443"
     },
     {
+        "id": "WEB_HOST",
+        "label": "Enter the IP address to bind.",
+        "type": "text",
+        "default": ""
+    },
+    {
         "id": "Force_SSL",
         "label": "Select to force https",
         "type": "bool",

--- a/Contents/Resources/language_template.html
+++ b/Contents/Resources/language_template.html
@@ -43,6 +43,9 @@ SAMPLES BELOW:
     <PLUGIN>Enter the port that this plugin should use for https. Do NOT use [1900, 3005, 5353, 8324, 32400, 32410, 32412, 32413, 32414, 32469]</PLUGIN>
 </translate>
 <translate>
+    <PLUGIN>Enter the local ip address to bind.</PLUGIN>
+</translate>
+<translate>
     <PLUGIN>Select to force https</PLUGIN>
 </translate>
 <translate>


### PR DESCRIPTION
Like the title says.  

Problem it solves: Aside from the obvious more-control-is-better, Tornado reports binding a host-only address on my computer instead of the network available interface.  